### PR TITLE
refactor request and response to make them usable outside GravitonApi

### DIFF
--- a/gdk-core/src/main/java/com/github/libgraviton/gdk/GravitonFileEndpoint.java
+++ b/gdk-core/src/main/java/com/github/libgraviton/gdk/GravitonFileEndpoint.java
@@ -1,6 +1,6 @@
 package com.github.libgraviton.gdk;
 
-import com.github.libgraviton.gdk.api.GravitonRequest;
+import com.github.libgraviton.gdk.api.Request;
 import com.github.libgraviton.gdk.api.header.HeaderBag;
 import com.github.libgraviton.gdk.api.multipart.Part;
 import com.github.libgraviton.gdk.data.GravitonBase;
@@ -29,7 +29,7 @@ public class GravitonFileEndpoint {
         this.gravitonApi = gravitonApi;
     }
 
-    public GravitonRequest.Builder getFile(String url) {
+    public Request.Builder getFile(String url) {
         LOG.debug("Requesting file");
 
         // without the 'Accept' - 'application/json' header, we get the file instead of the metadata
@@ -43,28 +43,28 @@ public class GravitonFileEndpoint {
                 .get();
     }
 
-    public GravitonRequest.Builder getFile(GravitonBase resource) {
+    public Request.Builder getFile(GravitonBase resource) {
         return getFile(gravitonApi.extractId(resource), resource.getClass());
     }
 
-    public GravitonRequest.Builder getFile(String id, Class clazz) {
+    public Request.Builder getFile(String id, Class clazz) {
         return getFile(gravitonApi.getEndpointManager().getEndpoint(clazz.getName()).getItemUrl()).addParam("id", id);
     }
 
-    public GravitonRequest.Builder getMetadata(String url) {
+    public Request.Builder getMetadata(String url) {
         LOG.debug("Requesting file metadata");
         return gravitonApi.get(url);
     }
 
-    public GravitonRequest.Builder getMetadata(GravitonBase resource) {
+    public Request.Builder getMetadata(GravitonBase resource) {
         return getMetadata(gravitonApi.extractId(resource), resource.getClass());
     }
 
-    public GravitonRequest.Builder getMetadata(String id, Class clazz) {
+    public Request.Builder getMetadata(String id, Class clazz) {
         return getMetadata(gravitonApi.getEndpointManager().getEndpoint(clazz.getName()).getItemUrl()).addParam("id", id);
     }
 
-    public GravitonRequest.Builder post(byte[] data, GravitonBase resource) throws SerializationException {
+    public Request.Builder post(byte[] data, GravitonBase resource) throws SerializationException {
         Part dataPart = new Part(data, "upload");
         Part metadataPart = new Part(gravitonApi.serializeResource(resource), "metadata");
 
@@ -74,22 +74,22 @@ public class GravitonFileEndpoint {
                 .post(dataPart, metadataPart);
     }
 
-    public GravitonRequest.Builder put(byte[] data, GravitonBase resource) throws SerializationException {
+    public Request.Builder put(byte[] data, GravitonBase resource) throws SerializationException {
         Part dataPart = new Part(data, "upload");
         Part metadataPart = new Part(gravitonApi.serializeResource(resource), "metadata");
 
         return gravitonApi.request()
-                .setUrl(gravitonApi.getEndpointManager().getEndpoint(resource.getClass().getName()).getUrl())
+                .setUrl(gravitonApi.getEndpointManager().getEndpoint(resource.getClass().getName()).getItemUrl())
                 .addParam("id", gravitonApi.extractId(resource))
                 .setHeaders(new HeaderBag.Builder().build())
                 .put(dataPart, metadataPart);
     }
 
-    public GravitonRequest.Builder patch(GravitonBase resource) throws SerializationException {
+    public Request.Builder patch(GravitonBase resource) throws SerializationException {
         return gravitonApi.patch(resource);
     }
 
-    public GravitonRequest.Builder delete(GravitonBase resource) {
+    public Request.Builder delete(GravitonBase resource) {
         return gravitonApi.delete(resource);
     }
 

--- a/gdk-core/src/main/java/com/github/libgraviton/gdk/RequestExecutor.java
+++ b/gdk-core/src/main/java/com/github/libgraviton/gdk/RequestExecutor.java
@@ -1,0 +1,103 @@
+package com.github.libgraviton.gdk;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.libgraviton.gdk.api.Request;
+import com.github.libgraviton.gdk.api.Response;
+import com.github.libgraviton.gdk.api.gateway.GravitonGateway;
+import com.github.libgraviton.gdk.api.gateway.OkHttpGateway;
+import com.github.libgraviton.gdk.api.multipart.Part;
+import com.github.libgraviton.gdk.exception.CommunicationException;
+import com.github.libgraviton.gdk.exception.UnsuccessfulResponseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is the base class used for Graviton API calls.
+ *
+ * @author List of contributors {@literal <https://github.com/libgraviton/gdk-java/graphs/contributors>}
+ * @see <a href="http://swisscom.ch">http://swisscom.ch</a>
+ * @version $Id: $Id
+ */
+public class RequestExecutor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RequestExecutor.class);
+
+    /**
+     * The object mapper used to serialize / deserialize to / from JSON
+     */
+    protected ObjectMapper objectMapper;
+
+    /**
+     * The http client for making http calls.
+     */
+    protected GravitonGateway gateway;
+
+    public RequestExecutor() {
+        this(new ObjectMapper());
+    }
+
+    public RequestExecutor(ObjectMapper objectMapper) {
+        this.gateway = new OkHttpGateway();
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Executes a given Graviton request.
+     *
+     * @param request The Graviton request
+     *
+     * @return The corresponding Graviton response
+     *
+     * @throws CommunicationException If the request was not successful
+     */
+    public Response execute(Request request) throws CommunicationException {
+        LOG.info(String.format("Starting '%s' to '%s'...", request.getMethod(), request.getUrl()));
+        if(LOG.isDebugEnabled()) {
+            logBody(request);
+        }
+
+        Response response = gateway.execute(request);
+        response.setObjectMapper(getObjectMapper());
+
+        if(response.isSuccessful()) {
+            LOG.info(String.format(
+                    "Successful '%s' to '%s'. Response was '%d' - '%s'.",
+                    request.getMethod(),
+                    request.getUrl(),
+                    response.getCode(),
+                    response.getMessage()
+            ));
+        } else {
+            throw new UnsuccessfulResponseException(response);
+        }
+        return response;
+    }
+
+    protected void logBody(Request request) {
+        // log standard request
+        if (request.getBody() != null) {
+            LOG.debug("with request body '" + request.getBody() + "'");
+        }
+
+        // log multipart request
+        if (request.getParts() != null && request.getParts().size() > 0) {
+            StringBuilder builder = new StringBuilder();
+            for (Part part: request.getParts()) {
+                builder.append(part).append("\n");
+            }
+            LOG.debug("with multipart request body [\n" + builder.toString() + "]");
+        }
+    }
+
+    public void setGateway(GravitonGateway gateway) {
+        this.gateway = gateway;
+    }
+
+    public void setObjectMapper(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public ObjectMapper getObjectMapper() {
+        return objectMapper;
+    }
+}

--- a/gdk-core/src/main/java/com/github/libgraviton/gdk/api/Request.java
+++ b/gdk-core/src/main/java/com/github/libgraviton/gdk/api/Request.java
@@ -1,6 +1,6 @@
 package com.github.libgraviton.gdk.api;
 
-import com.github.libgraviton.gdk.GravitonApi;
+import com.github.libgraviton.gdk.RequestExecutor;
 import com.github.libgraviton.gdk.api.header.HeaderBag;
 import com.github.libgraviton.gdk.api.multipart.Part;
 import com.github.libgraviton.gdk.exception.CommunicationException;
@@ -13,7 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class GravitonRequest {
+public class Request {
 
     private URL url;
 
@@ -21,14 +21,14 @@ public class GravitonRequest {
 
     private HeaderBag headers;
 
-    private String body;
+    private byte[] body;
 
     private List<Part> parts;
 
-    protected GravitonRequest() {
+    protected Request() {
     }
 
-    protected GravitonRequest(Builder builder) throws MalformedURLException {
+    protected Request(Builder builder) throws MalformedURLException {
         method = builder.method;
         url = builder.buildUrl();
         headers = builder.headerBuilder.build();
@@ -48,8 +48,12 @@ public class GravitonRequest {
         return headers;
     }
 
-    public String getBody() {
+    public byte[] getBodyBytes() {
         return body;
+    }
+
+    public String getBody() {
+        return body != null ? new String(body) : null;
     }
 
     public List<Part> getParts() {
@@ -70,15 +74,18 @@ public class GravitonRequest {
 
         private HeaderBag.Builder headerBuilder = new HeaderBag.Builder();
 
-        private String body;
+        private byte[] body;
 
         private List<Part> parts = new ArrayList<>();
 
-        private GravitonApi gravitonApi;
+        private RequestExecutor executor;
 
-        public Builder(GravitonApi gravitonApi){
-            this.gravitonApi = gravitonApi;
-            setHeaders(getDefaultHeaders());
+        public Builder() {
+            this.executor = new RequestExecutor();
+        }
+
+        public Builder(RequestExecutor executor) {
+            this.executor = executor;
         }
 
         public Builder setUrl(URL url) {
@@ -120,6 +127,11 @@ public class GravitonRequest {
         }
 
         public Builder setBody(String body) {
+            this.body = body.getBytes();
+            return this;
+        }
+
+        public Builder setBody(byte[] body) {
             this.body = body;
             return this;
         }
@@ -178,25 +190,17 @@ public class GravitonRequest {
             return setMethod(HttpMethod.PATCH).setBody(data);
         }
 
-        public GravitonRequest build() throws MalformedURLException {
-            return new GravitonRequest(this);
+        public Request build() throws MalformedURLException {
+            return new Request(this);
         }
 
-        public GravitonResponse execute() throws CommunicationException {
+        public Response execute() throws CommunicationException {
             try {
-                return gravitonApi.execute(build());
+                return executor.execute(build());
             } catch (MalformedURLException e) {
                 throw new UnsuccessfulRequestException(String.format("'%s' to '%s' failed due to malformed url.", method, url),
                         e);
             }
-        }
-
-        // TODO make it configurable
-        protected HeaderBag getDefaultHeaders() {
-            return new HeaderBag.Builder()
-                    .set("Content-Type", "application/json")
-                    .set("Accept", "application/json")
-                    .build();
         }
 
         protected URL buildUrl() throws MalformedURLException {

--- a/gdk-core/src/main/java/com/github/libgraviton/gdk/api/Response.java
+++ b/gdk-core/src/main/java/com/github/libgraviton/gdk/api/Response.java
@@ -16,9 +16,9 @@ import java.util.List;
  * @see <a href="http://swisscom.ch">http://swisscom.ch</a>
  * @version $Id: $Id
  */
-public class GravitonResponse {
+public class Response {
 
-    private GravitonRequest request;
+    private Request request;
 
     private int code;
 
@@ -32,10 +32,10 @@ public class GravitonResponse {
 
     private ObjectMapper objectMapper;
 
-    protected GravitonResponse() {
+    protected Response() {
     }
 
-    protected GravitonResponse(GravitonResponse.Builder builder) {
+    protected Response(Response.Builder builder) {
         request = builder.request;
         code = builder.code;
         isSuccessful = builder.isSuccessful;
@@ -57,18 +57,18 @@ public class GravitonResponse {
      * @throws DeserializationException will be thrown on a failed deserialization / POJO mapping
      */
     public <BeanClass> BeanClass getBodyItem(final Class<? extends BeanClass> beanClass) throws DeserializationException {
-        if(objectMapper == null) {
+        if(getObjectMapper() == null) {
             throw new IllegalStateException("'objectMapper' is not allowed to be null.");
         }
 
         try {
-            BeanClass pojoValue = objectMapper.readValue(getBody(), beanClass);
-            JsonPatcher.add(pojoValue, objectMapper.valueToTree(pojoValue));
+            BeanClass pojoValue = getObjectMapper().readValue(getBody(), beanClass);
+            JsonPatcher.add(pojoValue, getObjectMapper().valueToTree(pojoValue));
             return pojoValue;
         } catch (IOException e) {
             throw new DeserializationException(String.format(
                     "Unable to deserialize response body from '%s' to class '%s'.",
-                    request.getUrl(),
+                    getRequest().getUrl(),
                     beanClass.getName()
             ), e);
         }
@@ -83,22 +83,22 @@ public class GravitonResponse {
      * @throws DeserializationException will be thrown on a failed deserialization / POJO mapping
      */
     public <BeanClass> List<BeanClass> getBodyItems(final Class<? extends BeanClass> beanClass) throws DeserializationException {
-        if(objectMapper == null) {
+        if(getObjectMapper() == null) {
             throw new IllegalStateException("'objectMapper' is not allowed to be null.");
         }
 
         try {
             final CollectionType javaType =
-                    objectMapper.getTypeFactory().constructCollectionType(List.class, beanClass);
-            List<BeanClass> pojoValues = objectMapper.readValue(getBody(), javaType);
+                    getObjectMapper().getTypeFactory().constructCollectionType(List.class, beanClass);
+            List<BeanClass> pojoValues = getObjectMapper().readValue(getBody(), javaType);
             for (BeanClass pojoValue : pojoValues) {
-                JsonPatcher.add(pojoValue, objectMapper.valueToTree(pojoValue));
+                JsonPatcher.add(pojoValue, getObjectMapper().valueToTree(pojoValue));
             }
             return pojoValues;
         } catch (IOException e) {
             throw new DeserializationException(String.format(
                     "Unable to deserialize response body from '%s' to class '%s'.",
-                    request.getUrl(),
+                    getRequest().getUrl(),
                     beanClass.getName()
             ), e);
         }
@@ -109,7 +109,7 @@ public class GravitonResponse {
      * @return response body as String
      */
     public String getBody() {
-        return new String(body);
+        return body != null ? new String(body) : null;
     }
 
     /**
@@ -125,10 +125,14 @@ public class GravitonResponse {
         return headers;
     }
 
-    public GravitonRequest getRequest() {
+    public Request getRequest() {
         return request;
     }
 
+
+    public ObjectMapper getObjectMapper() {
+        return objectMapper;
+    }
     public void setObjectMapper(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
@@ -147,7 +151,7 @@ public class GravitonResponse {
 
         private String message;
 
-        private GravitonRequest request;
+        private Request request;
 
         private byte[] body;
 
@@ -155,7 +159,7 @@ public class GravitonResponse {
 
         private HeaderBag.Builder headerBuilder;
 
-        public Builder(GravitonRequest request) {
+        public Builder(Request request) {
             this.request = request;
             headerBuilder = new HeaderBag.Builder();
         }
@@ -185,8 +189,8 @@ public class GravitonResponse {
             return this;
         }
 
-        public GravitonResponse build() {
-            return new GravitonResponse(this);
+        public Response build() {
+            return new Response(this);
         }
 
     }

--- a/gdk-core/src/main/java/com/github/libgraviton/gdk/api/gateway/GravitonGateway.java
+++ b/gdk-core/src/main/java/com/github/libgraviton/gdk/api/gateway/GravitonGateway.java
@@ -1,11 +1,11 @@
 package com.github.libgraviton.gdk.api.gateway;
 
-import com.github.libgraviton.gdk.api.GravitonRequest;
-import com.github.libgraviton.gdk.api.GravitonResponse;
+import com.github.libgraviton.gdk.api.Request;
+import com.github.libgraviton.gdk.api.Response;
 import com.github.libgraviton.gdk.exception.CommunicationException;
 
 public interface GravitonGateway {
 
-    GravitonResponse execute(GravitonRequest request) throws CommunicationException;
+    Response execute(Request request) throws CommunicationException;
 
 }

--- a/gdk-core/src/main/java/com/github/libgraviton/gdk/api/gateway/OkHttpGateway.java
+++ b/gdk-core/src/main/java/com/github/libgraviton/gdk/api/gateway/OkHttpGateway.java
@@ -62,7 +62,7 @@ public class OkHttpGateway implements GravitonGateway {
         return requestBuilder
                 .method(request.getMethod().asString(), okHttpBody)
                 .url(request.getUrl())
-                .headers(createHeaders(request.getHeaders()))
+                .headers(createRequestHeaders(request.getHeaders()))
                 .build();
     }
 
@@ -92,14 +92,14 @@ public class OkHttpGateway implements GravitonGateway {
         com.github.libgraviton.gdk.api.Response.Builder responseBuilder = new com.github.libgraviton.gdk.api.Response.Builder(request);
         return responseBuilder
                 .code(okHttpResponse.code())
-                .headers(createHeaders(okHttpResponse.headers()))
+                .headers(createResponseHeaders(okHttpResponse.headers()))
                 .message(okHttpResponse.message())
                 .successful(okHttpResponse.isSuccessful())
                 .body(body)
                 .build();
     }
 
-    private Headers createHeaders(HeaderBag headerBag) {
+    protected Headers createRequestHeaders(HeaderBag headerBag) {
         Headers.Builder builder = new Headers.Builder();
         for (Map.Entry<String, Header> header : headerBag.all().entrySet()) {
             for (String value : header.getValue()) {
@@ -109,7 +109,7 @@ public class OkHttpGateway implements GravitonGateway {
         return builder.build();
     }
 
-    private HeaderBag.Builder createHeaders(Headers okhttpHeaders) {
+    protected HeaderBag.Builder createResponseHeaders(Headers okhttpHeaders) {
         HeaderBag.Builder builder = new HeaderBag.Builder();
         for (Map.Entry<String, List<String>> header : okhttpHeaders.toMultimap().entrySet()) {
             builder.set(header.getKey(), header.getValue());

--- a/gdk-core/src/main/java/com/github/libgraviton/gdk/api/gateway/OkHttpGateway.java
+++ b/gdk-core/src/main/java/com/github/libgraviton/gdk/api/gateway/OkHttpGateway.java
@@ -1,15 +1,13 @@
 package com.github.libgraviton.gdk.api.gateway;
 
-import com.github.libgraviton.gdk.api.GravitonRequest;
-import com.github.libgraviton.gdk.api.GravitonResponse;
+import com.github.libgraviton.gdk.api.Request;
+import com.github.libgraviton.gdk.api.Response;
 import com.github.libgraviton.gdk.api.header.Header;
 import com.github.libgraviton.gdk.api.header.HeaderBag;
 import com.github.libgraviton.gdk.api.multipart.Part;
 import com.github.libgraviton.gdk.exception.CommunicationException;
 import com.github.libgraviton.gdk.exception.UnsuccessfulRequestException;
 import okhttp3.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.List;
@@ -34,10 +32,10 @@ public class OkHttpGateway implements GravitonGateway {
         this.okHttp = okHttp;
     }
 
-    public GravitonResponse execute(GravitonRequest request) throws CommunicationException {
-        Request okHttpRequest = generateRequest(request);
+    public Response execute(Request request) throws CommunicationException {
+        okhttp3.Request okHttpRequest = generateRequest(request);
 
-        Response okHttpResponse;
+        okhttp3.Response okHttpResponse;
         byte[] body;
         try {
             okHttpResponse = okHttp.newCall(okHttpRequest).execute();
@@ -52,7 +50,7 @@ public class OkHttpGateway implements GravitonGateway {
         return generateResponse(request, okHttpResponse, body);
     }
 
-    private Request generateRequest(GravitonRequest request) {
+    private okhttp3.Request generateRequest(Request request) {
         RequestBody okHttpBody;
         if (request.isMultipartRequest()) {
             okHttpBody = generateMultipartRequestBody(request);
@@ -60,7 +58,7 @@ public class OkHttpGateway implements GravitonGateway {
             okHttpBody = generateDefaultRequestBody(request);
         }
 
-        Request.Builder requestBuilder = new Request.Builder();
+        okhttp3.Request.Builder requestBuilder = new okhttp3.Request.Builder();
         return requestBuilder
                 .method(request.getMethod().asString(), okHttpBody)
                 .url(request.getUrl())
@@ -68,7 +66,7 @@ public class OkHttpGateway implements GravitonGateway {
                 .build();
     }
 
-    private RequestBody generateMultipartRequestBody(GravitonRequest request) {
+    private RequestBody generateMultipartRequestBody(Request request) {
         MultipartBody.Builder builder = new MultipartBody.Builder();
         for (Part part : request.getParts()) {
             MultipartBody.Part bodyPart;
@@ -85,13 +83,13 @@ public class OkHttpGateway implements GravitonGateway {
         return builder.build();
     }
 
-    private RequestBody generateDefaultRequestBody(GravitonRequest request) {
-        return null == request.getBody() ? null :
-                RequestBody.create(MediaType.parse(request.getHeaders().get("Content-Type") + "; charset=utf-8"), request.getBody());
+    private RequestBody generateDefaultRequestBody(Request request) {
+        return null == request.getBodyBytes() ? null :
+                RequestBody.create(MediaType.parse(request.getHeaders().get("Content-Type") + "; charset=utf-8"), request.getBodyBytes());
     }
 
-    private GravitonResponse generateResponse(GravitonRequest request, Response okHttpResponse, byte[] body) {
-        GravitonResponse.Builder responseBuilder = new GravitonResponse.Builder(request);
+    private com.github.libgraviton.gdk.api.Response generateResponse(Request request, okhttp3.Response okHttpResponse, byte[] body) {
+        com.github.libgraviton.gdk.api.Response.Builder responseBuilder = new com.github.libgraviton.gdk.api.Response.Builder(request);
         return responseBuilder
                 .code(okHttpResponse.code())
                 .headers(createHeaders(okHttpResponse.headers()))

--- a/gdk-core/src/main/java/com/github/libgraviton/gdk/exception/UnsuccessfulRequestException.java
+++ b/gdk-core/src/main/java/com/github/libgraviton/gdk/exception/UnsuccessfulRequestException.java
@@ -5,10 +5,6 @@ package com.github.libgraviton.gdk.exception;
  */
 public class UnsuccessfulRequestException extends CommunicationException {
 
-    public UnsuccessfulRequestException(String message) {
-        super(message);
-    }
-
     public UnsuccessfulRequestException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/gdk-core/src/main/java/com/github/libgraviton/gdk/exception/UnsuccessfulResponseException.java
+++ b/gdk-core/src/main/java/com/github/libgraviton/gdk/exception/UnsuccessfulResponseException.java
@@ -1,15 +1,15 @@
 package com.github.libgraviton.gdk.exception;
 
-import com.github.libgraviton.gdk.api.GravitonResponse;
+import com.github.libgraviton.gdk.api.Response;
 
 /**
  * Whenever a received response code is not within 200 - 299.
  */
 public class UnsuccessfulResponseException extends CommunicationException {
 
-    private GravitonResponse response;
+    private Response response;
 
-    public UnsuccessfulResponseException(GravitonResponse response) {
+    public UnsuccessfulResponseException(Response response) {
         super(generateMessage(response));
         this.response = response;
     }
@@ -22,11 +22,11 @@ public class UnsuccessfulResponseException extends CommunicationException {
         super(message, cause);
     }
 
-    public GravitonResponse getResponse() {
+    public Response getResponse() {
         return response;
     }
 
-    private static String generateMessage(GravitonResponse response) {
+    private static String generateMessage(Response response) {
         return String.format(
                 "Failed '%s' to '%s'. Response was '%d' - '%s' with body '%s'.",
                 response.getRequest().getMethod(),

--- a/gdk-core/src/main/java/com/github/libgraviton/gdk/exception/UnsuccessfulResponseException.java
+++ b/gdk-core/src/main/java/com/github/libgraviton/gdk/exception/UnsuccessfulResponseException.java
@@ -14,14 +14,6 @@ public class UnsuccessfulResponseException extends CommunicationException {
         this.response = response;
     }
 
-    public UnsuccessfulResponseException(String message) {
-        super(message);
-    }
-
-    public UnsuccessfulResponseException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
     public Response getResponse() {
         return response;
     }

--- a/gdk-core/src/main/java/com/github/libgraviton/gdk/generator/instructionloader/grvprofile/GrvProfileInstructionLoader.java
+++ b/gdk-core/src/main/java/com/github/libgraviton/gdk/generator/instructionloader/grvprofile/GrvProfileInstructionLoader.java
@@ -1,8 +1,8 @@
 package com.github.libgraviton.gdk.generator.instructionloader.grvprofile;
 
-import com.github.libgraviton.gdk.api.endpoint.Endpoint;
 import com.github.libgraviton.gdk.GravitonApi;
-import com.github.libgraviton.gdk.api.GravitonResponse;
+import com.github.libgraviton.gdk.api.Response;
+import com.github.libgraviton.gdk.api.endpoint.Endpoint;
 import com.github.libgraviton.gdk.exception.CommunicationException;
 import com.github.libgraviton.gdk.exception.SerializationException;
 import com.github.libgraviton.gdk.generator.GeneratorInstruction;
@@ -75,7 +75,7 @@ public class GrvProfileInstructionLoader implements GeneratorInstructionLoader {
             for (EndpointDefinition endpointDefinition : endpointDefinitions) {
                 String profileJson = null;
                 try {
-                    GravitonResponse response = gravitonApi.get(endpointDefinition.getProfile()).execute();
+                    Response response = gravitonApi.get(endpointDefinition.getProfile()).execute();
                     profileJson = response.getBody();
                 } catch (CommunicationException e) {
                     LOG.warn("Unable to fetch profile from '" + endpointDefinition.getProfile() + "'. Skipping...");
@@ -122,7 +122,7 @@ public class GrvProfileInstructionLoader implements GeneratorInstructionLoader {
      * @return The Graviton service.
      */
     private Service loadService() throws CommunicationException, SerializationException {
-        GravitonResponse response = gravitonApi.get(gravitonApi.getBaseUrl()).execute();
+        Response response = gravitonApi.get(gravitonApi.getBaseUrl()).execute();
         return response.getBodyItem(Service.class);
     }
 

--- a/gdk-core/src/main/java/com/github/libgraviton/gdk/generator/instructionloader/grvprofile/Service.java
+++ b/gdk-core/src/main/java/com/github/libgraviton/gdk/generator/instructionloader/grvprofile/Service.java
@@ -1,6 +1,9 @@
 package com.github.libgraviton.gdk.generator.instructionloader.grvprofile;
 
-import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 /**

--- a/gdk-core/src/main/java/com/github/libgraviton/gdk/serialization/JsonPatcher.java
+++ b/gdk-core/src/main/java/com/github/libgraviton/gdk/serialization/JsonPatcher.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.WeakHashMap;
 
 /**
- * Keeps track of POJOs there were deserialized via GravitonResponse (with its JsonNode in its original form),
+ * Keeps track of POJOs there were deserialized via Response (with its JsonNode in its original form),
  * so that the JSON Patch Diff can be calculated between the original and the current object state.
  *
  * @author List of contributors {@literal <https://github.com/libgraviton/gdk-java/graphs/contributors>}

--- a/gdk-core/src/test/java/com/github/libgraviton/gdk/GravitonApiTest.java
+++ b/gdk-core/src/test/java/com/github/libgraviton/gdk/GravitonApiTest.java
@@ -2,14 +2,12 @@ package com.github.libgraviton.gdk;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.libgraviton.gdk.api.GravitonRequest;
-import com.github.libgraviton.gdk.api.GravitonResponse;
+import com.github.libgraviton.gdk.api.Request;
+import com.github.libgraviton.gdk.api.Response;
 import com.github.libgraviton.gdk.api.endpoint.Endpoint;
 import com.github.libgraviton.gdk.api.endpoint.EndpointManager;
-import com.github.libgraviton.gdk.api.gateway.OkHttpGateway;
 import com.github.libgraviton.gdk.data.NoopClass;
 import com.github.libgraviton.gdk.data.SimpleClass;
-import com.github.libgraviton.gdk.exception.CommunicationException;
 import com.github.libgraviton.gdk.exception.SerializationException;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,7 +20,7 @@ public class GravitonApiTest {
 
     private GravitonApi gravitonApi;
 
-    private GravitonResponse response;
+    private Response response;
 
     private String itemUrl = "http://someUrl/item123";
 
@@ -34,23 +32,23 @@ public class GravitonApiTest {
     public void setupService() throws Exception {
         EndpointManager endpointManager = mock(EndpointManager.class);
         Endpoint endpoint = mock(Endpoint.class);
-        OkHttpGateway gateway = mock(OkHttpGateway.class);
-        response = mock(GravitonResponse.class);
+        RequestExecutor executor = mock(RequestExecutor.class);
+        response = mock(Response.class);
         when(response.isSuccessful()).thenReturn(true);
         when(endpoint.getItemUrl()).thenReturn(itemUrl);
         when(endpoint.getUrl()).thenReturn(endpointUrl);
         when(endpointManager.getEndpoint(anyString())).thenReturn(endpoint);
-        when(gateway.execute(any(GravitonRequest.class))).thenReturn(response);
+        when(executor.execute(any(Request.class))).thenReturn(response);
 
         gravitonApi = spy(new GravitonApi(baseUrl, endpointManager));
-        gravitonApi.setGateway(gateway);
+        gravitonApi.setRequestExecutor(executor);
     }
 
     @Test
     public void testGet() throws Exception {
         SimpleClass resource = new SimpleClass();
         resource.setId("111");
-        GravitonResponse actualResponse = gravitonApi.get(resource).execute();
+        Response actualResponse = gravitonApi.get(resource).execute();
         assertEquals(response, actualResponse);
     }
 
@@ -58,7 +56,7 @@ public class GravitonApiTest {
     public void testPut() throws Exception {
         SimpleClass resource = new SimpleClass();
         resource.setId("111");
-        GravitonResponse actualResponse = gravitonApi.put(resource).execute();
+        Response actualResponse = gravitonApi.put(resource).execute();
         assertEquals(response, actualResponse);
     }
 
@@ -66,14 +64,14 @@ public class GravitonApiTest {
     public void testPatch() throws Exception {
         SimpleClass resource = new SimpleClass();
         resource.setId("111");
-        GravitonResponse actualResponse = gravitonApi.patch(resource).execute();
+        Response actualResponse = gravitonApi.patch(resource).execute();
         assertEquals(response, actualResponse);
     }
 
     @Test
     public void testPost() throws Exception {
         SimpleClass resource = new SimpleClass();
-        GravitonResponse actualResponse = gravitonApi.post(resource).execute();
+        Response actualResponse = gravitonApi.post(resource).execute();
         assertEquals(response, actualResponse);
     }
 
@@ -91,7 +89,7 @@ public class GravitonApiTest {
     public void testDelete() throws Exception {
         SimpleClass resource = new SimpleClass();
         resource.setId("111");
-        GravitonResponse actualResponse = gravitonApi.delete(resource).execute();
+        Response actualResponse = gravitonApi.delete(resource).execute();
         assertEquals(response, actualResponse);
     }
 
@@ -99,14 +97,14 @@ public class GravitonApiTest {
     public void testHead() throws Exception {
         SimpleClass resource = new SimpleClass();
         resource.setId("111");
-        GravitonResponse actualResponse = gravitonApi.head(resource).execute();
+        Response actualResponse = gravitonApi.head(resource).execute();
         assertEquals(response, actualResponse);
     }
 
     @Test
     public void testOptions() throws Exception {
         SimpleClass resource = new SimpleClass();
-        GravitonResponse actualResponse = gravitonApi.options(resource).execute();
+        Response actualResponse = gravitonApi.options(resource).execute();
         assertEquals(response, actualResponse);
     }
 
@@ -117,15 +115,5 @@ public class GravitonApiTest {
         resource.setId("111");
         assertEquals("", gravitonApi.extractId(resourceWithoutId));
         assertEquals("111", gravitonApi.extractId(resource));
-    }
-
-    @Test(expected = CommunicationException.class)
-    public void testExecuteFail() throws Exception {
-        when(response.isSuccessful()).thenReturn(false);
-        when(response.getRequest()).thenReturn(mock(GravitonRequest.class));
-
-        SimpleClass resource = new SimpleClass();
-        resource.setId("111");
-        gravitonApi.get(resource).execute();
     }
 }

--- a/gdk-core/src/test/java/com/github/libgraviton/gdk/GravitonFileEndpointTest.java
+++ b/gdk-core/src/test/java/com/github/libgraviton/gdk/GravitonFileEndpointTest.java
@@ -1,8 +1,9 @@
 package com.github.libgraviton.gdk;
 
-import com.github.libgraviton.gdk.api.GravitonRequest;
+import com.github.libgraviton.gdk.api.Request;
 import com.github.libgraviton.gdk.api.endpoint.Endpoint;
 import com.github.libgraviton.gdk.api.endpoint.EndpointManager;
+import com.github.libgraviton.gdk.api.header.HeaderBag;
 import com.github.libgraviton.gdk.api.multipart.Part;
 import com.github.libgraviton.gdk.data.GravitonBase;
 import com.github.libgraviton.gdk.data.SimpleClass;
@@ -40,6 +41,11 @@ public class GravitonFileEndpointTest {
         when(gravitonApi.getEndpointManager()).thenReturn(endpointManager);
         when(gravitonApi.extractId(any(GravitonBase.class))).thenCallRealMethod();
         when(gravitonApi.serializeResource(any(SimpleClass.class))).thenReturn("{ \"id\":\"111\"}");
+        HeaderBag headers = new HeaderBag.Builder()
+                .set("whatever", "something")
+                .build();
+
+        when(gravitonApi.getDefaultHeaders()).thenReturn(headers);
         resource = new SimpleClass();
         resource.setId("111");
 
@@ -48,14 +54,15 @@ public class GravitonFileEndpointTest {
 
     @Test
     public void testGetFile() throws Exception {
-        GravitonRequest request = gravitonFileEndpoint.getFile(url).build();
+        Request request = gravitonFileEndpoint.getFile(url).build();
         assertEquals(0, request.getHeaders().get("Accept").all().size());
+        assertEquals(1, request.getHeaders().get("Content-Type").all().size());
     }
 
     @Test
     public void testGetMetadata() throws Exception {
-        GravitonRequest request = gravitonFileEndpoint.getMetadata(url).build();
-        assertEquals(1, request.getHeaders().get("Accept").all().size());
+        Request request = gravitonFileEndpoint.getMetadata(url).build();
+        assertEquals(1, request.getHeaders().get("whatever").all().size());
         verify(gravitonApi, times(1)).get(url);
     }
 
@@ -63,7 +70,7 @@ public class GravitonFileEndpointTest {
     public void testPost() throws Exception {
         String data = "some real data";
 
-        GravitonRequest request = gravitonFileEndpoint.post(data.getBytes(), resource).build();
+        Request request = gravitonFileEndpoint.post(data.getBytes(), resource).build();
         List<Part> parts = request.getParts();
         assertEquals(2, parts.size());
 
@@ -80,7 +87,7 @@ public class GravitonFileEndpointTest {
     public void testPut() throws Exception {
         String data = "some real data";
 
-        GravitonRequest request = gravitonFileEndpoint.put(data.getBytes(), resource).build();
+        Request request = gravitonFileEndpoint.put(data.getBytes(), resource).build();
         List<Part> parts = request.getParts();
         assertEquals(2, parts.size());
 

--- a/gdk-core/src/test/java/com/github/libgraviton/gdk/RequestExecutorTest.java
+++ b/gdk-core/src/test/java/com/github/libgraviton/gdk/RequestExecutorTest.java
@@ -1,0 +1,59 @@
+package com.github.libgraviton.gdk;
+
+import com.github.libgraviton.gdk.api.HttpMethod;
+import com.github.libgraviton.gdk.api.Request;
+import com.github.libgraviton.gdk.api.Response;
+import com.github.libgraviton.gdk.api.gateway.GravitonGateway;
+import com.github.libgraviton.gdk.exception.CommunicationException;
+import com.github.libgraviton.gdk.exception.UnsuccessfulResponseException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RequestExecutorTest {
+
+    private RequestExecutor executor;
+
+    private GravitonGateway gateway;
+
+    @Before
+    public void setup() {
+        executor = new RequestExecutor();
+        gateway = mock(GravitonGateway.class);
+        executor.setGateway(gateway);
+    }
+
+    @Test
+    public void testExecuteSuccessfulResponse() throws CommunicationException {
+        Request request = mock(Request.class);
+        Response response = mock(Response.class);
+        when(response.isSuccessful()).thenReturn(true);
+        when(gateway.execute(eq(request))).thenReturn(response);
+
+        Response actualResponse = executor.execute(request);
+        assertEquals(response, actualResponse);
+    }
+
+    @Test(expected = UnsuccessfulResponseException.class)
+    public void testExecuteUnsuccessfulResponse() throws Exception {
+        Request request = mock(Request.class);
+        when(request.getMethod()).thenReturn(HttpMethod.GET);
+        when(request.getUrl()).thenReturn(new URL("http://some-test-url"));
+        Response response = mock(Response.class);
+        when(response.isSuccessful()).thenReturn(false);
+        when(response.getRequest()).thenReturn(request);
+        when(response.getCode()).thenReturn(500);
+        when(response.getMessage()).thenReturn("Oops!");
+        when(response.getBody()).thenReturn("Content");
+        when(gateway.execute(eq(request))).thenReturn(response);
+
+        Response actualResponse = executor.execute(request);
+        assertEquals(response, actualResponse);
+    }
+}

--- a/gdk-core/src/test/java/com/github/libgraviton/gdk/api/RequestTest.java
+++ b/gdk-core/src/test/java/com/github/libgraviton/gdk/api/RequestTest.java
@@ -1,6 +1,6 @@
 package com.github.libgraviton.gdk.api;
 
-import com.github.libgraviton.gdk.GravitonApi;
+import com.github.libgraviton.gdk.RequestExecutor;
 import com.github.libgraviton.gdk.api.multipart.Part;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,14 +13,14 @@ import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
-public class GravitonApiRequestTest {
+public class RequestTest {
 
-    private GravitonRequest.Builder builder;
+    private Request.Builder builder;
 
     @Before
     public void setup() throws Exception {
-        GravitonApi gravitonApi = mock(GravitonApi.class);
-        builder = new GravitonRequest.Builder(gravitonApi).setUrl("http://aRandomUrl");
+        RequestExecutor executor = mock(RequestExecutor.class);
+        builder = new Request.Builder(executor).setUrl("http://aRandomUrl");
     }
 
     @Test
@@ -31,7 +31,7 @@ public class GravitonApiRequestTest {
 
     @Test
     public void testGet() throws Exception {
-        GravitonRequest request = builder.get().build();
+        Request request = builder.get().build();
         assertEquals(HttpMethod.GET, request.getMethod());
         assertNull(request.getBody());
     }
@@ -39,7 +39,7 @@ public class GravitonApiRequestTest {
     @Test
     public void testPut() throws Exception {
         String data = "putData";
-        GravitonRequest request = builder.put(data).build();
+        Request request = builder.put(data).build();
         assertEquals(HttpMethod.PUT, request.getMethod());
         assertEquals(data, request.getBody());
     }
@@ -47,7 +47,7 @@ public class GravitonApiRequestTest {
     @Test
     public void testPost() throws Exception {
         String data = "postData";
-        GravitonRequest request = builder.post(data).build();
+        Request request = builder.post(data).build();
         assertEquals(HttpMethod.POST, request.getMethod());
         assertEquals(data, request.getBody());
     }
@@ -55,28 +55,28 @@ public class GravitonApiRequestTest {
     @Test
     public void testPatch() throws Exception {
         String data = "patchData";
-        GravitonRequest request = builder.patch(data).build();
+        Request request = builder.patch(data).build();
         assertEquals(HttpMethod.PATCH, request.getMethod());
         assertEquals(data, request.getBody());
     }
 
     @Test
     public void testDelete() throws Exception {
-        GravitonRequest request = builder.delete().build();
+        Request request = builder.delete().build();
         assertEquals(HttpMethod.DELETE, request.getMethod());
         assertNull(request.getBody());
     }
 
     @Test
     public void testHead() throws Exception {
-        GravitonRequest request = builder.head().build();
+        Request request = builder.head().build();
         assertEquals(HttpMethod.HEAD, request.getMethod());
         assertNull(request.getBody());
     }
 
     @Test
     public void testOptions() throws Exception {
-        GravitonRequest request = builder.options().build();
+        Request request = builder.options().build();
         assertEquals(HttpMethod.OPTIONS, request.getMethod());
         assertNull(request.getBody());
     }
@@ -89,7 +89,7 @@ public class GravitonApiRequestTest {
         Part part1 = new Part(body1, formName);
         Part part2 = new Part(body2);
 
-        GravitonRequest request = builder.post(part1, part2).build();
+        Request request = builder.post(part1, part2).build();
         assertEquals(HttpMethod.POST, request.getMethod());
         List<Part> parts = request.getParts();
         assertEquals(2, parts.size());
@@ -102,7 +102,7 @@ public class GravitonApiRequestTest {
         String body = "body part ";
         Part part = new Part(body);
 
-        GravitonRequest request = builder.put(part).build();
+        Request request = builder.put(part).build();
         assertEquals(HttpMethod.PUT, request.getMethod());
         List<Part> parts = request.getParts();
         assertEquals(1, parts.size());
@@ -137,16 +137,14 @@ public class GravitonApiRequestTest {
         String param2 = "param2";
         String value1 = "value1";
         String value2 = "value2";
-        GravitonRequest request = builder.build();
-        assertEquals(2, request.getHeaders().all().size());
-        assertEquals("application/json", request.getHeaders().get("Content-Type").get(0));
-        assertEquals("application/json", request.getHeaders().get("Accept").get(0));
+        Request request = builder.build();
+        assertEquals(0, request.getHeaders().all().size());
         request = builder.addHeader(param1, value1).build();
-        assertEquals(3, request.getHeaders().all().size());
+        assertEquals(1, request.getHeaders().all().size());
         assertEquals(value1, request.getHeaders().get(param1).get(0));
 
         request = builder.addHeader(param2, value2).build();
-        assertEquals(4, request.getHeaders().all().size());
+        assertEquals(2, request.getHeaders().all().size());
         assertEquals(value2, request.getHeaders().get(param2).get(0));
 
         request = builder.setHeaders(null).build();

--- a/gdk-core/src/test/java/com/github/libgraviton/gdk/api/ResponseTest.java
+++ b/gdk-core/src/test/java/com/github/libgraviton/gdk/api/ResponseTest.java
@@ -14,16 +14,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-public class GravitonApiResponseTest {
+public class ResponseTest {
 
-    private GravitonResponse response;
+    private Response response;
 
-    private GravitonRequest request;
+    private Request request;
 
     @Before
     public void setup() throws Exception {
-        request = mock(GravitonRequest.class);
-        response = new GravitonResponse.Builder(request)
+        request = mock(Request.class);
+        response = new Response.Builder(request)
                 .body("{\"code\":0}".getBytes())
                 .successful(true)
                 .message("a message")
@@ -68,7 +68,7 @@ public class GravitonApiResponseTest {
         testClass2.setCode(2);
         List<SerializationTestClass> testClasses = Arrays.asList(testClass1, testClass2);
 
-        response = new GravitonResponse.Builder(request)
+        response = new Response.Builder(request)
                 .body(new ObjectMapper().writeValueAsString(testClasses).getBytes())
                 .successful(true)
                 .message("a message")

--- a/gdk-core/src/test/java/com/github/libgraviton/gdk/api/gateway/OkHttpGatewayTest.java
+++ b/gdk-core/src/test/java/com/github/libgraviton/gdk/api/gateway/OkHttpGatewayTest.java
@@ -1,12 +1,14 @@
 package com.github.libgraviton.gdk.api.gateway;
 
 
-import com.github.libgraviton.gdk.GravitonApi;
-import com.github.libgraviton.gdk.api.GravitonRequest;
-import com.github.libgraviton.gdk.api.GravitonResponse;
+import com.github.libgraviton.gdk.RequestExecutor;
 import com.github.libgraviton.gdk.api.HttpMethod;
+import com.github.libgraviton.gdk.api.Request;
 import com.github.libgraviton.gdk.exception.CommunicationException;
-import okhttp3.*;
+import okhttp3.Call;
+import okhttp3.Headers;
+import okhttp3.OkHttpClient;
+import okhttp3.ResponseBody;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -21,9 +23,9 @@ public class OkHttpGatewayTest {
 
     private OkHttpGateway gateway;
 
-    private GravitonRequest request;
+    private Request request;
 
-    private Response okHttpResponse;
+    private okhttp3.Response okHttpResponse;
 
     private Call call;
 
@@ -35,10 +37,10 @@ public class OkHttpGatewayTest {
     public void setup() throws Exception {
         OkHttpClient client = mock(OkHttpClient.class);
         gateway = new OkHttpGateway(client);
-        okHttpResponse = mock(Response.class);
+        okHttpResponse = mock(okhttp3.Response.class);
         when(okHttpResponse.headers()).thenReturn(new Headers.Builder().build());
-        GravitonApi gravitonApi = mock(GravitonApi.class);
-        request = new GravitonRequest.Builder(gravitonApi)
+        RequestExecutor executor = mock(RequestExecutor.class);
+        request = new Request.Builder(executor)
                 .setMethod(HttpMethod.GET)
                 .setUrl("http://someUrl")
                 .build();
@@ -46,7 +48,7 @@ public class OkHttpGatewayTest {
         // mock client.newCall()
         call = mock(Call.class);
         when(call.execute()).thenReturn(okHttpResponse);
-        when(client.newCall(any(Request.class))).thenReturn(call);
+        when(client.newCall(any(okhttp3.Request.class))).thenReturn(call);
 
         // mock okHttpResponse.setBody().string()
         body = mock(ResponseBody.class);
@@ -58,7 +60,7 @@ public class OkHttpGatewayTest {
     public void testDoRequestHappyPath() throws CommunicationException {
         when(okHttpResponse.isSuccessful()).thenReturn(true);
 
-        GravitonResponse response = gateway.execute(request);
+        com.github.libgraviton.gdk.api.Response response = gateway.execute(request);
         assertEquals(responseBody, response.getBody());
     }
 

--- a/gdk-core/src/test/java/com/github/libgraviton/gdk/api/gateway/OkHttpGatewayTest.java
+++ b/gdk-core/src/test/java/com/github/libgraviton/gdk/api/gateway/OkHttpGatewayTest.java
@@ -4,6 +4,7 @@ package com.github.libgraviton.gdk.api.gateway;
 import com.github.libgraviton.gdk.RequestExecutor;
 import com.github.libgraviton.gdk.api.HttpMethod;
 import com.github.libgraviton.gdk.api.Request;
+import com.github.libgraviton.gdk.api.header.HeaderBag;
 import com.github.libgraviton.gdk.exception.CommunicationException;
 import okhttp3.Call;
 import okhttp3.Headers;
@@ -84,6 +85,43 @@ public class OkHttpGatewayTest {
         }
 
         gateway.execute(request);
+    }
+
+    @Test
+    public void testCreateRequestHeaders() {
+        String header1 = "header1";
+        String header2 = "header2";
+        String value1 = "value1";
+        String value2 = "value2";
+
+        HeaderBag headers = new HeaderBag.Builder()
+                .set(header1, value1)
+                .set(header2, value2)
+                .build();
+
+        Headers requestHeaders = gateway.createRequestHeaders(headers);
+        assertEquals(2, requestHeaders.size());
+        assertEquals(value1, requestHeaders.get(header1));
+        assertEquals(value2, requestHeaders.get(header2));
+    }
+
+    @Test
+    public void testCreateResponseHeaders() {
+        String header1 = "header1";
+        String header2 = "header2";
+        String value1 = "value1";
+        String value2 = "value2";
+
+        Headers headers = new Headers.Builder()
+                .set(header1, value1)
+                .set(header2, value2)
+                .build();
+
+        HeaderBag responseHeaders = gateway.createResponseHeaders(headers)
+                .build();
+        assertEquals(2, responseHeaders.all().size());
+        assertEquals(value1, responseHeaders.get(header1).get(0));
+        assertEquals(value2, responseHeaders.get(header2).get(0));
     }
 
 }

--- a/gdk-core/src/test/java/com/github/libgraviton/gdk/generator/instructionloader/grvprofile/GrvProfileInstructionModeTest.java
+++ b/gdk-core/src/test/java/com/github/libgraviton/gdk/generator/instructionloader/grvprofile/GrvProfileInstructionModeTest.java
@@ -2,8 +2,8 @@ package com.github.libgraviton.gdk.generator.instructionloader.grvprofile;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.libgraviton.gdk.GravitonApi;
-import com.github.libgraviton.gdk.api.GravitonRequest;
-import com.github.libgraviton.gdk.api.GravitonResponse;
+import com.github.libgraviton.gdk.api.Request;
+import com.github.libgraviton.gdk.api.Response;
 import com.github.libgraviton.gdk.generator.GeneratorInstruction;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
@@ -49,27 +49,27 @@ public class GrvProfileInstructionModeTest {
         gravitonApi = mock(GravitonApi.class, withSettings());
         when(gravitonApi.getBaseUrl()).thenReturn("http://gravitonApi");
 
-        GravitonResponse response1 = mock(GravitonResponse.class);
+        Response response1 = mock(Response.class);
         when(response1.getBodyItem(Service.class)).thenReturn(objectMapper.readValue(service, Service.class));
-        GravitonRequest.Builder builder1 = mock(GravitonRequest.Builder.class);
+        Request.Builder builder1 = mock(Request.Builder.class);
         when(builder1.execute()).thenReturn(response1);
         when(gravitonApi.get("http://gravitonApi")).thenReturn(builder1);
 
-        GravitonResponse response2 = mock(GravitonResponse.class);
+        Response response2 = mock(Response.class);
         when(response2.getBody()).thenReturn(someSchema);
-        GravitonRequest.Builder builder2 = mock(GravitonRequest.Builder.class);
+        Request.Builder builder2 = mock(Request.Builder.class);
         when(builder2.execute()).thenReturn(response2);
         when(gravitonApi.get("http://some-service/profile")).thenReturn(builder2);
 
-        GravitonResponse response3 = mock(GravitonResponse.class);
+        Response response3 = mock(Response.class);
         when(response3.getBody()).thenReturn(anotherSchema);
-        GravitonRequest.Builder builder3 = mock(GravitonRequest.Builder.class);
+        Request.Builder builder3 = mock(Request.Builder.class);
         when(builder2.execute()).thenReturn(response3);
         when(gravitonApi.get("http://another-service/profile")).thenReturn(builder3);
 
-        GravitonResponse response4 = mock(GravitonResponse.class);
+        Response response4 = mock(Response.class);
         when(response4.getBody()).thenReturn(someMoreSchema);
-        GravitonRequest.Builder builder4 = mock(GravitonRequest.Builder.class);
+        Request.Builder builder4 = mock(Request.Builder.class);
         when(builder4.execute()).thenReturn(response4);
         when(gravitonApi.get("http://some-more-service/profile")).thenReturn(builder4);
 
@@ -125,9 +125,9 @@ public class GrvProfileInstructionModeTest {
             int instructionIndex
     ) throws Exception{
         String schema = FileUtils.readFileToString(new File("src/test/resources/" + schemaFile));
-        GravitonResponse response = mock(GravitonResponse.class);
+        Response response = mock(Response.class);
         doReturn(schema).when(response).getBody();
-        GravitonRequest.Builder builder = mock(GravitonRequest.Builder.class);
+        Request.Builder builder = mock(Request.Builder.class);
         when(builder.execute()).thenReturn(response);
         when(gravitonApi.get(not(eq("http://gravitonApi")))).thenReturn(builder);
 

--- a/gdk-maven-plugin/src/main/java/org/jsonschema2pojo/rules/NonSingularArrayRule.java
+++ b/gdk-maven-plugin/src/main/java/org/jsonschema2pojo/rules/NonSingularArrayRule.java
@@ -11,7 +11,7 @@ import java.util.Set;
 
 /**
  * Array rule that doesn't change the nodeName but else behaves the same as ArrayRule.
- * Since the makeSingular method within ArrayRule is private, this class here is copy & own.
+ * Since the makeSingular method within ArrayRule is private, this class here is copy and own.
  */
 public class NonSingularArrayRule implements Rule<JPackage, JClass> {
 


### PR DESCRIPTION
Refactor of the Request and the Response classes to allow usage of the underlined GDK communications library without using GravitonApi.

Beside the renaming the most interesting part in this PR is the RequestExecutor.