### PR TITLE
Feature/javadoc conform pojo generation

### DIFF
--- a/gdk-core/pom.xml
+++ b/gdk-core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.github.libgraviton</groupId>
         <artifactId>gdk</artifactId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>${gdkVersion}</version>
     </parent>
     <artifactId>gdk-core</artifactId>
     <name>gdk-core</name>

--- a/gdk-core/pom.xml
+++ b/gdk-core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.github.libgraviton</groupId>
         <artifactId>gdk</artifactId>
-        <version>${project.version}</version>
+        <version>0.2.1-SNAPSHOT</version>
     </parent>
     <artifactId>gdk-core</artifactId>
     <name>gdk-core</name>

--- a/gdk-core/pom.xml
+++ b/gdk-core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.github.libgraviton</groupId>
         <artifactId>gdk</artifactId>
-        <version>${gdkVersion}</version>
+        <version>${project.version}</version>
     </parent>
     <artifactId>gdk-core</artifactId>
     <name>gdk-core</name>

--- a/gdk-core/pom.xml
+++ b/gdk-core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.github.libgraviton</groupId>
         <artifactId>gdk</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.2.1-SNAPSHOT</version>
     </parent>
     <artifactId>gdk-core</artifactId>
     <name>gdk-core</name>

--- a/gdk-maven-plugin/pom.xml
+++ b/gdk-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.libgraviton</groupId>
         <artifactId>gdk</artifactId>
-        <version>${gdkVersion}</version>
+        <version>${project.version}</version>
     </parent>
     <artifactId>gdk-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.github.libgraviton</groupId>
             <artifactId>gdk-core</artifactId>
-            <version>${gdkVersion}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jsonschema2pojo</groupId>

--- a/gdk-maven-plugin/pom.xml
+++ b/gdk-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.libgraviton</groupId>
         <artifactId>gdk</artifactId>
-        <version>0.2.1-SNAPSHOT</version>
+        <version>${gdkVersion}</version>
     </parent>
     <artifactId>gdk-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>

--- a/gdk-maven-plugin/pom.xml
+++ b/gdk-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.libgraviton</groupId>
         <artifactId>gdk</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.2.1-SNAPSHOT</version>
     </parent>
     <artifactId>gdk-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>

--- a/gdk-maven-plugin/pom.xml
+++ b/gdk-maven-plugin/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.github.libgraviton</groupId>
             <artifactId>gdk-core</artifactId>
-            <version>0.1.1-SNAPSHOT</version>
+            <version>${gdkVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.jsonschema2pojo</groupId>

--- a/gdk-maven-plugin/pom.xml
+++ b/gdk-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.libgraviton</groupId>
         <artifactId>gdk</artifactId>
-        <version>${project.version}</version>
+        <version>0.2.1-SNAPSHOT</version>
     </parent>
     <artifactId>gdk-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>com.github.libgraviton</groupId>
             <artifactId>gdk-core</artifactId>
-            <version>${project.version}</version>
+            <version>0.2.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jsonschema2pojo</groupId>

--- a/gdk-maven-plugin/src/main/java/org/jsonschema2pojo/rules/FilteredDescriptionRule.java
+++ b/gdk-maven-plugin/src/main/java/org/jsonschema2pojo/rules/FilteredDescriptionRule.java
@@ -28,7 +28,7 @@ public class FilteredDescriptionRule extends DescriptionRule {
 
         String text = node.asText();
         if (text != null) {
-            javadoc.add(0, text.replaceAll("@", ""));
+            javadoc.add(text.replaceAll("@", ""));
         }
 
         return javadoc;

--- a/gdk-maven-plugin/src/main/java/org/jsonschema2pojo/rules/FilteredDescriptionRule.java
+++ b/gdk-maven-plugin/src/main/java/org/jsonschema2pojo/rules/FilteredDescriptionRule.java
@@ -1,0 +1,37 @@
+package org.jsonschema2pojo.rules;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JDocComment;
+import com.sun.codemodel.JDocCommentable;
+import org.jsonschema2pojo.Schema;
+
+/**
+ * Same as DescriptionRule, but but removes all '@' characters to avoid the generation of corrupt javadoc.
+ */
+public class FilteredDescriptionRule extends DescriptionRule {
+
+    /**
+     * Create the javadoc from the title it takes from the schema.
+     *
+     * @param nodeName
+     *            the name of the property to which this title applies
+     * @param node
+     *            the "title" schema node
+     * @param generatableType
+     *            comment-able code generation construct, usually a field or
+     *            method, which should have this title applied
+     * @return the JavaDoc comment created to contain the title
+     */
+    @Override
+    public JDocComment apply(String nodeName, JsonNode node, JDocCommentable generatableType, Schema schema) {
+        JDocComment javadoc = generatableType.javadoc();
+
+        String text = node.asText();
+        if (text != null) {
+            javadoc.add(0, text.replaceAll("@", ""));
+        }
+
+        return javadoc;
+    }
+
+}

--- a/gdk-maven-plugin/src/main/java/org/jsonschema2pojo/rules/FilteredTitleRule.java
+++ b/gdk-maven-plugin/src/main/java/org/jsonschema2pojo/rules/FilteredTitleRule.java
@@ -1,0 +1,39 @@
+package org.jsonschema2pojo.rules;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.*;
+import org.jsonschema2pojo.Schema;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Same as TitleRule, but without the 'p' tag and removes all '@' characters to avoid the generation of corrupt javadoc.
+ */
+public class FilteredTitleRule extends TitleRule {
+
+    /**
+     * Create the javadoc from the description it takes from the schema.
+     *
+     * @param nodeName
+     *            the name of the property to which this title applies
+     * @param node
+     *            the "title" schema node
+     * @param generatableType
+     *            comment-able code generation construct, usually a field or
+     *            method, which should have this title applied
+     * @return the JavaDoc comment created to contain the title
+     */
+    @Override
+    public JDocComment apply(String nodeName, JsonNode node, JDocCommentable generatableType, Schema schema) {
+        JDocComment javadoc = generatableType.javadoc();
+
+        String text = node.asText();
+        if (text != null) {
+            javadoc.add(0, text.replaceAll("@", "") + "\n");
+        }
+
+        return javadoc;
+    }
+
+}

--- a/gdk-maven-plugin/src/main/java/org/jsonschema2pojo/rules/GravitonRuleFactory.java
+++ b/gdk-maven-plugin/src/main/java/org/jsonschema2pojo/rules/GravitonRuleFactory.java
@@ -1,6 +1,8 @@
 package org.jsonschema2pojo.rules;
 
 import com.sun.codemodel.JClass;
+import com.sun.codemodel.JDocComment;
+import com.sun.codemodel.JDocCommentable;
 import com.sun.codemodel.JPackage;
 
 /**
@@ -11,5 +13,15 @@ public class GravitonRuleFactory extends RuleFactory {
     @Override
     public Rule<JPackage, JClass> getArrayRule() {
         return new NonSingularArrayRule(this);
+    }
+
+    @Override
+    public Rule<JDocCommentable, JDocComment> getTitleRule() {
+        return new FilteredTitleRule();
+    }
+
+    @Override
+    public Rule<JDocCommentable, JDocComment> getDescriptionRule() {
+        return new FilteredDescriptionRule();
     }
 }

--- a/gdk-maven-plugin/src/test/java/org/jsonschema2pojo/rules/FilteredDescriptionRuleTest.java
+++ b/gdk-maven-plugin/src/test/java/org/jsonschema2pojo/rules/FilteredDescriptionRuleTest.java
@@ -1,0 +1,32 @@
+package org.jsonschema2pojo.rules;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JDocComment;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FilteredDescriptionRuleTest {
+
+    private static final String TARGET_CLASS_NAME = FilteredDescriptionRuleTest.class.getName() + ".DummyClass";
+
+    @Test
+    public void testApply() throws Exception {
+        JDefinedClass jclass = new JCodeModel()._class(TARGET_CLASS_NAME);
+
+        JsonNode node = mock(JsonNode.class);
+        when(node.asText()).thenReturn("@todo a description");
+        FilteredDescriptionRule rule = new FilteredDescriptionRule();
+        JDocComment jDocComment = rule.apply(null, node, jclass, null);
+
+        assertThat(jDocComment, sameInstance(jclass.javadoc()));
+        assertThat(jDocComment.size(), is(1));
+        assertThat((String) jDocComment.get(0), is("todo a description"));
+    }
+}

--- a/gdk-maven-plugin/src/test/java/org/jsonschema2pojo/rules/FilteredTitleRuleTest.java
+++ b/gdk-maven-plugin/src/test/java/org/jsonschema2pojo/rules/FilteredTitleRuleTest.java
@@ -1,0 +1,32 @@
+package org.jsonschema2pojo.rules;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.codemodel.JCodeModel;
+import com.sun.codemodel.JDefinedClass;
+import com.sun.codemodel.JDocComment;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FilteredTitleRuleTest {
+
+    private static final String TARGET_CLASS_NAME = FilteredTitleRuleTest.class.getName() + ".DummyClass";
+
+    @Test
+    public void testApply() throws Exception {
+        JDefinedClass jclass = new JCodeModel()._class(TARGET_CLASS_NAME);
+
+        JsonNode node = mock(JsonNode.class);
+        when(node.asText()).thenReturn("@todo a title");
+        FilteredTitleRule rule = new FilteredTitleRule();
+        JDocComment jDocComment = rule.apply(null, node, jclass, null);
+
+        assertThat(jDocComment, sameInstance(jclass.javadoc()));
+        assertThat(jDocComment.size(), is(1));
+        assertThat((String) jDocComment.get(0), is("todo a title\n"));
+    }
+}

--- a/gdk-maven-plugin/src/test/java/org/jsonschema2pojo/rules/GravitonRuleFactoryTest.java
+++ b/gdk-maven-plugin/src/test/java/org/jsonschema2pojo/rules/GravitonRuleFactoryTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertTrue;
 
 public class GravitonRuleFactoryTest {
 
-    GravitonRuleFactory ruleFactory;
+    private GravitonRuleFactory ruleFactory;
 
     @Before
     public void setup() {
@@ -17,5 +17,15 @@ public class GravitonRuleFactoryTest {
     @Test
     public void testGetArrayRule() {
         assertTrue(ruleFactory.getArrayRule() instanceof NonSingularArrayRule);
+    }
+
+    @Test
+    public void testGetTitleRule() {
+        assertTrue(ruleFactory.getTitleRule() instanceof FilteredTitleRule);
+    }
+
+    @Test
+    public void testGetDescriptionRule() {
+        assertTrue(ruleFactory.getDescriptionRule() instanceof FilteredDescriptionRule);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.libgraviton</groupId>
     <artifactId>gdk</artifactId>
-    <version>${gdkVersion}</version>
+    <version>0.2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>gdk</name>
     <description>Graviton Development Kit</description>
@@ -40,7 +40,6 @@
     </scm>
 
     <properties>
-        <gdkVersion>0.2.1-SNAPSHOT</gdkVersion>
         <jsonschema2PojoVersion>0.4.28-SNAPSHOT</jsonschema2PojoVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.libgraviton</groupId>
     <artifactId>gdk</artifactId>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>${gdkVersion}</version>
     <packaging>pom</packaging>
     <name>gdk</name>
     <description>Graviton Development Kit</description>
@@ -40,6 +40,7 @@
     </scm>
 
     <properties>
+        <gdkVersion>0.2.1-SNAPSHOT</gdkVersion>
         <jsonschema2PojoVersion>0.4.28-SNAPSHOT</jsonschema2PojoVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
An adaption was needed to make sure the javadoc in the generated classes is not corrupt in a sense that the 'maven-javadoc-plugin' will not complain.

Additionally the ${gdkVersion} variable has been introduced to all pom.xml files.