### PR TITLE
Feature/system properties path

### DIFF
--- a/gdk-core/src/main/java/com/github/libgraviton/gdk/api/endpoint/GeneratedEndpointManager.java
+++ b/gdk-core/src/main/java/com/github/libgraviton/gdk/api/endpoint/GeneratedEndpointManager.java
@@ -3,8 +3,11 @@ package com.github.libgraviton.gdk.api.endpoint;
 import com.github.libgraviton.gdk.api.endpoint.exception.UnableToLoadEndpointAssociationsException;
 import com.github.libgraviton.gdk.api.endpoint.exception.UnableToPersistEndpointAssociationsException;
 import com.github.libgraviton.gdk.util.PropertiesLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -12,6 +15,8 @@ import java.util.Map;
  * association to a file and deserialize it afterwards.
  */
 public class GeneratedEndpointManager extends EndpointManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GeneratedEndpointManager.class);
 
     public enum Mode {
         LOAD, CREATE
@@ -81,6 +86,7 @@ public class GeneratedEndpointManager extends EndpointManager {
             ObjectInputStream objectinputstream = new ObjectInputStream(loadInputStream());
             endpoints = (Map<String, Endpoint>) objectinputstream.readObject();
             objectinputstream.close();
+            LOG.debug(endpoints.size() + " endpoints loaded");
         } catch (IOException e) {
             throw new UnableToLoadEndpointAssociationsException(
                     "Unable to deserialize '" + assocFilePath + "'.",
@@ -104,9 +110,11 @@ public class GeneratedEndpointManager extends EndpointManager {
 
     protected InputStream loadInputStream() throws UnableToLoadEndpointAssociationsException {
         // try to load as resource first
+        LOG.debug("Load resource as stream from '" + assocFilePath + "'.");
         InputStream inputStream = GeneratedEndpointManager.class.getClassLoader().getResourceAsStream(assocFilePath);
 
         if(inputStream == null && serializationFile.exists()) {
+            LOG.debug("Resource not found. Fallback to serialization file '" + serializationFile.getAbsolutePath() + "'.");
             try {
                 // resource not found? Try to load as file
                 inputStream = new FileInputStream(serializationFile);

--- a/gdk-core/src/main/java/com/github/libgraviton/gdk/util/PropertiesLoader.java
+++ b/gdk-core/src/main/java/com/github/libgraviton/gdk/util/PropertiesLoader.java
@@ -1,11 +1,12 @@
 package com.github.libgraviton.gdk.util;
 
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
 /**
- * Loading properties (default as fallback, with the ability to overwrite values).
+ * Loading properties (with the ability to overwrite values).
  */
 public class PropertiesLoader {
 
@@ -13,15 +14,21 @@ public class PropertiesLoader {
 
     private static final String OVERWRITE_PROPERTIES_PATH = "app.properties";
 
+    private static final String SYSTEM_PROPERTY = "propFile";
+
     /**
      * Loads the Properties in the following order (if a property entry ia already loaded, it will be overridden with the new value).
-     * 1.) Default Properties
+     * 1.) Default Properties (resource path)
      *     Minimal needed properties for the gdk
      *
-     * 2.) Overwrite Properties
+     * 2.) Overwrite Properties (resource path)
      *     Usually projects that make use of the gdk library will define these properties.
      *
-     * 3.) System Properties
+     * 3.) Overwrite Properties (system property path)
+     *     Whenever the project needs to run as a jar file with an external properties file,
+     *     it's required to pass the SYSTEM_PROPERTY key with the path to the properties file as value. (e.g. -DpropFile=/app.properties)
+     *
+     * 4.) System Properties
      *     Projects that use the gdk library could be deployed to several environments that require different property values.
      *     The easiest way at this point is to just redefine those properties as system properties.
      *
@@ -37,6 +44,13 @@ public class PropertiesLoader {
 
         try (InputStream overwriteProperties = PropertiesLoader.class.getClassLoader().getResourceAsStream(OVERWRITE_PROPERTIES_PATH)) {
             if (overwriteProperties != null) {
+                properties.load(overwriteProperties);
+            }
+        }
+
+        String systemPropertiesPath = System.getProperty(SYSTEM_PROPERTY);
+        if (systemPropertiesPath != null) {
+            try (InputStream overwriteProperties = new FileInputStream(systemPropertiesPath)) {
                 properties.load(overwriteProperties);
             }
         }


### PR DESCRIPTION
Whenever the project needs to run as a jar file with an external properties file, it's required to pass the SYSTEM_PROPERTY key with the path to the properties file as value.
(e.g. -DpropFile=/app.properties)