### PR TITLE
EVO-9085 Adding Auth header for simple worker auth

### DIFF
--- a/gdk-core/src/main/java/com/github/libgraviton/gdk/GravitonApi.java
+++ b/gdk-core/src/main/java/com/github/libgraviton/gdk/GravitonApi.java
@@ -34,6 +34,11 @@ public class GravitonApi {
      */
     private String baseUrl;
 
+    /** Workers id to be used in each request for subnet authentication to api */
+    private String workerId;
+    /** Header authentication name */
+    private String authHeaderName;
+
     /**
      * The object mapper used to serialize / deserialize to / from JSON
      */
@@ -51,6 +56,8 @@ public class GravitonApi {
     public GravitonApi() {
         setup();
         this.baseUrl = properties.getProperty("graviton.base.url");
+        this.workerId = properties.getProperty("graviton.workerId");
+        this.authHeaderName = properties.getProperty("graviton.authentication.header.name");
 
         try {
             this.endpointManager = initEndpointManager();
@@ -61,6 +68,8 @@ public class GravitonApi {
 
     public GravitonApi(String baseUrl, EndpointManager endpointManager) {
         setup();
+        this.workerId = "subnet-base";
+        this.authHeaderName = "x-graviton";
         this.baseUrl = baseUrl;
         this.endpointManager = endpointManager;
     }
@@ -234,9 +243,11 @@ public class GravitonApi {
 
     // TODO make it configurable
     protected HeaderBag getDefaultHeaders() {
+        String subnetName = "subnet-" + workerId;
         return new HeaderBag.Builder()
                 .set("Content-Type", "application/json")
                 .set("Accept", "application/json")
+                .set(authHeaderName, subnetName)
                 .build();
     }
 }

--- a/gdk-core/src/main/resources/default-gdk.properties
+++ b/gdk-core/src/main/resources/default-gdk.properties
@@ -8,3 +8,6 @@ graviton.timezone=UTC
 
 # location to load / store the POJO -> endpoint association
 graviton.assoc.file.location=target/generated-sources/gdk-java/assoc
+
+# Graviton Api Subnet authentication
+graviton.authentication.header.name=x-graviton-authentication


### PR DESCRIPTION
Workers are running in same network but needs to identify them self against api.
Api Security have a Subnet role that will be assigned to those calls from same network.
Here we just inform about the “username” of what worker was accessing the api.