### PR TITLE
Feature/file endpoint default headers

### DIFF
--- a/gdk-core/src/main/java/com/github/libgraviton/gdk/GravitonApi.java
+++ b/gdk-core/src/main/java/com/github/libgraviton/gdk/GravitonApi.java
@@ -104,7 +104,7 @@ public class GravitonApi {
      */
     public Request.Builder request() {
         return new Request.Builder(executor)
-                .setHeaders(getDefaultHeaders());
+                .setHeaders(getDefaultHeaders().build());
     }
 
     public Request.Builder head(String url) {
@@ -233,10 +233,9 @@ public class GravitonApi {
     }
 
     // TODO make it configurable
-    protected HeaderBag getDefaultHeaders() {
+    protected HeaderBag.Builder getDefaultHeaders() {
         return new HeaderBag.Builder()
                 .set("Content-Type", "application/json")
-                .set("Accept", "application/json")
-                .build();
+                .set("Accept", "application/json");
     }
 }

--- a/gdk-core/src/main/java/com/github/libgraviton/gdk/GravitonFileEndpoint.java
+++ b/gdk-core/src/main/java/com/github/libgraviton/gdk/GravitonFileEndpoint.java
@@ -33,13 +33,12 @@ public class GravitonFileEndpoint {
         LOG.debug("Requesting file");
 
         // without the 'Accept' - 'application/json' header, we get the file instead of the metadata
-        HeaderBag headers = new HeaderBag.Builder()
-                .set("Content-Type", "application/json")
-                .build();
+        HeaderBag.Builder headers = gravitonApi.getDefaultHeaders()
+                .unset("Accept");
 
         return gravitonApi.request()
                 .setUrl(url)
-                .setHeaders(headers)
+                .setHeaders(headers.build())
                 .get();
     }
 
@@ -68,9 +67,13 @@ public class GravitonFileEndpoint {
         Part dataPart = new Part(data, "upload");
         Part metadataPart = new Part(gravitonApi.serializeResource(resource), "metadata");
 
+        HeaderBag.Builder headers = gravitonApi.getDefaultHeaders()
+                .unset("Accept")
+                .unset("Content-Type");
+
         return gravitonApi.request()
                 .setUrl(gravitonApi.getEndpointManager().getEndpoint(resource.getClass().getName()).getUrl())
-                .setHeaders(new HeaderBag.Builder().build())
+                .setHeaders(headers.build())
                 .post(dataPart, metadataPart);
     }
 
@@ -78,10 +81,14 @@ public class GravitonFileEndpoint {
         Part dataPart = new Part(data, "upload");
         Part metadataPart = new Part(gravitonApi.serializeResource(resource), "metadata");
 
+        HeaderBag.Builder headers = gravitonApi.getDefaultHeaders()
+                .unset("Accept")
+                .unset("Content-Type");
+
         return gravitonApi.request()
                 .setUrl(gravitonApi.getEndpointManager().getEndpoint(resource.getClass().getName()).getItemUrl())
                 .addParam("id", gravitonApi.extractId(resource))
-                .setHeaders(new HeaderBag.Builder().build())
+                .setHeaders(headers.build())
                 .put(dataPart, metadataPart);
     }
 

--- a/gdk-core/src/main/java/com/github/libgraviton/gdk/RequestExecutor.java
+++ b/gdk-core/src/main/java/com/github/libgraviton/gdk/RequestExecutor.java
@@ -11,8 +11,6 @@ import com.github.libgraviton.gdk.exception.UnsuccessfulResponseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
-
 /**
  * This is the base class used for Graviton API calls.
  *

--- a/gdk-core/src/main/java/com/github/libgraviton/gdk/api/endpoint/GeneratedEndpointManager.java
+++ b/gdk-core/src/main/java/com/github/libgraviton/gdk/api/endpoint/GeneratedEndpointManager.java
@@ -7,7 +7,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
-import java.util.Iterator;
 import java.util.Map;
 
 /**

--- a/gdk-core/src/test/java/com/github/libgraviton/gdk/GravitonFileEndpointTest.java
+++ b/gdk-core/src/test/java/com/github/libgraviton/gdk/GravitonFileEndpointTest.java
@@ -41,9 +41,9 @@ public class GravitonFileEndpointTest {
         when(gravitonApi.getEndpointManager()).thenReturn(endpointManager);
         when(gravitonApi.extractId(any(GravitonBase.class))).thenCallRealMethod();
         when(gravitonApi.serializeResource(any(SimpleClass.class))).thenReturn("{ \"id\":\"111\"}");
-        HeaderBag headers = new HeaderBag.Builder()
+        HeaderBag.Builder headers = new HeaderBag.Builder()
                 .set("whatever", "something")
-                .build();
+                .set("Accept", "almost-everything");
 
         when(gravitonApi.getDefaultHeaders()).thenReturn(headers);
         resource = new SimpleClass();
@@ -56,7 +56,7 @@ public class GravitonFileEndpointTest {
     public void testGetFile() throws Exception {
         Request request = gravitonFileEndpoint.getFile(url).build();
         assertEquals(0, request.getHeaders().get("Accept").all().size());
-        assertEquals(1, request.getHeaders().get("Content-Type").all().size());
+        assertEquals(1, request.getHeaders().get("whatever").all().size());
     }
 
     @Test

--- a/gdk-core/src/test/java/com/github/libgraviton/gdk/api/NoopResponseTest.java
+++ b/gdk-core/src/test/java/com/github/libgraviton/gdk/api/NoopResponseTest.java
@@ -4,8 +4,6 @@ import com.github.libgraviton.gdk.exception.CommunicationException;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class NoopResponseTest {


### PR DESCRIPTION
Until now GravitonFileEndpoint always completely replaces the default headers set by GravitonApi. With this change the GravitonFileEndpoint benefits from the GravitonApi default headers and only cherry picks the single headers it wants gone (unset).

This leads to the effect that general needed header adaption need only be done at GravitonApi and not at GravitonFileEndpoint as well.